### PR TITLE
refactor: Temporarily remove GridSplitter for debugging

### DIFF
--- a/CustomExplorer.csproj
+++ b/CustomExplorer.csproj
@@ -14,7 +14,6 @@
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,7 +5,6 @@
     xmlns:local="using:CustomExplorer"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:controls="using:CommunityToolkit.WinUI.UI.Controls"
     mc:Ignorable="d">
 
     <Window.Resources>
@@ -34,8 +33,8 @@
             <!-- Folder Tree -->
             <TreeView x:Name="FolderTreeView" Grid.Column="0" Margin="5,0,0,5" />
 
-            <!-- Grid Splitter -->
-            <controls:GridSplitter Grid.Column="1" Width="5" HorizontalAlignment="Center" VerticalAlignment="Stretch" />
+            <!-- Grid Splitter (replaced with a simple Border) -->
+            <Border Grid.Column="1" Width="1" Background="LightGray" />
 
             <!-- File List -->
             <ListView x:Name="FileListView" Grid.Column="2" Margin="0,0,0,5">
@@ -70,8 +69,8 @@
                 </ListView.ItemTemplate>
             </ListView>
 
-            <!-- Grid Splitter -->
-            <controls:GridSplitter Grid.Column="3" Width="5" HorizontalAlignment="Center" VerticalAlignment="Stretch" />
+            <!-- Grid Splitter (replaced with a simple Border) -->
+            <Border Grid.Column="3" Width="1" Background="LightGray" />
 
             <!-- Details Pane -->
             <ScrollViewer Grid.Column="4" Margin="5">


### PR DESCRIPTION
To isolate the root cause of a persistent XAML build failure, this change removes the `GridSplitter` control and its dependency on the `CommunityToolkit.WinUI.UI.Controls` library.

- The package reference to `CommunityToolkit.WinUI.UI.Controls` has been removed from the `.csproj` file.
- The `GridSplitter` elements in `MainWindow.xaml` have been replaced with simple `Border` elements to maintain the visual layout without the external dependency.
- The corresponding XAML namespace has also been removed.