### PR TITLE
fix: Correct project file for WinUI 3 build

### DIFF
--- a/CustomExplorer.csproj
+++ b/CustomExplorer.csproj
@@ -8,11 +8,12 @@
     <Platforms>x86;x64;ARM64</Platforms>
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
+    <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240428000" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3447" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This commit attempts to fix a fundamental build issue where the project was not being correctly recognized as a WinUI 3 application, leading to XAML compiler errors like "Unknown member 'Resources' on element 'Window'".

- The property `<EnableMsixTooling>true</EnableMsixTooling>` has been added to the main PropertyGroup in the `.csproj` file. This is critical for enabling the correct build toolchain for packaged WinUI 3 applications.
- The versions for `Microsoft.WindowsAppSDK` and `Microsoft.Windows.SDK.BuildTools` have been updated to more recent stable releases to avoid potential version-mismatch issues.