### PR TITLE
refactor: Move XAML resource to App.xaml as workaround

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -10,6 +10,7 @@
                 <!-- Other merged dictionaries here -->
             </ResourceDictionary.MergedDictionaries>
             <!-- Other app resources here -->
+            <local:HexToBrushConverter x:Key="HexToBrushConverter"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -7,10 +7,6 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <Window.Resources>
-        <local:HexToBrushConverter x:Key="HexToBrushConverter"/>
-    </Window.Resources>
-
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />


### PR DESCRIPTION
This commit attempts to work around a persistent XAML build error (`WMC0011: Unknown member 'Resources' on element 'Window'`). The root cause appears to be a fundamental issue with the XAML compiler's ability to parse resources defined at the Window scope in this specific environment.

- The `<Window.Resources>` block containing the `HexToBrushConverter` has been removed from `MainWindow.xaml`.
- The `HexToBrushConverter` resource has been added to the `ResourceDictionary` in `App.xaml`, making it a global application resource. This should be functionally equivalent while potentially avoiding the compiler error.