### PR TITLE
fix: Configure project for self-contained deployment

### DIFF
--- a/CustomExplorer.csproj
+++ b/CustomExplorer.csproj
@@ -9,6 +9,7 @@
     <RuntimeIdentifiers>win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This commit resolves a `DllNotFoundException` for `Microsoft.ui.xaml.dll` that occurred at runtime. The application is now configured to be self-contained, bundling the Windows App SDK runtime with the app.

- Added `<WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>` to the project file to enable self-contained deployment. This eliminates the need for the end-user to have a specific version of the Windows App SDK runtime installed.