### PR TITLE
fix: Rebuild csproj from template and relocate resources

### DIFF
--- a/App.xaml
+++ b/App.xaml
@@ -11,10 +11,6 @@
             </ResourceDictionary.MergedDictionaries>
             <!-- Other app resources here -->
             <local:HexToBrushConverter x:Key="HexToBrushConverter"/>
-
-            <HierarchicalDataTemplate x:Key="FolderTreeTemplate" ItemsSource="{Binding Children}" x:DataType="local:FolderNode">
-                <TextBlock Text="{Binding Name}" />
-            </HierarchicalDataTemplate>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/CustomExplorer.csproj
+++ b/CustomExplorer.csproj
@@ -10,6 +10,12 @@
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+
+    <!-- Additions based on official templates -->
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+    <AppxPackageIsForStore>false</AppxPackageIsForStore>
+    <AppxPriInitialPath>Package.appxmanifest</AppxPriInitialPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -7,6 +7,12 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
+    <Window.Resources>
+        <HierarchicalDataTemplate x:Key="FolderTreeTemplate" ItemsSource="{Binding Children}" x:DataType="local:FolderNode">
+            <TextBlock Text="{Binding Name}" />
+        </HierarchicalDataTemplate>
+    </Window.Resources>
+
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />


### PR DESCRIPTION
This is a comprehensive attempt to fix a persistent XAML build failure (`WMC0001` and `WMC0011`).

- Overwrites `CustomExplorer.csproj` with a more complete structure based on official Microsoft templates. This adds properties like `AppxPackageSigningEnabled` and `DefaultLanguage` to ensure the project is correctly interpreted by the build toolchain.
- Moves the `HierarchicalDataTemplate` from the global `App.xaml` resources to the local `MainWindow.xaml` resources. This reverts to a configuration that was closer to a working state and may avoid XAML parsing issues.